### PR TITLE
Ta bort symbolisk länk

### DIFF
--- a/front-end/leaflet/static/landskap.geosjon
+++ b/front-end/leaflet/static/landskap.geosjon
@@ -1,1 +1,0 @@
-svenska-landskap-klippt.geo.json


### PR DESCRIPTION
Overleaf vägrar importera projekt som har någon symbolisk länk. Vet inte varför den finns. Det verkar inte finnsa någonstans när jag söker på det.